### PR TITLE
Modifier parsing bug fix

### DIFF
--- a/src/walk.ts
+++ b/src/walk.ts
@@ -121,9 +121,14 @@ const processDirective = (
 
   // modifiers
   let modMatch: RegExpExecArray | null = null
-  while ((modMatch = modifierRE.exec(raw))) {
+  let firstMod = true
+  let rawCopy = raw
+  while ((modMatch = modifierRE.exec(rawCopy))) {
     ;(modifiers || (modifiers = {}))[modMatch[1]] = true
-    raw = raw.slice(0, modMatch.index)
+    if (firstMod) {
+      raw = raw.slice(0, modMatch.index)
+      firstMod = false
+    }
   }
 
   if (raw[0] === ':') {


### PR DESCRIPTION
Currently petite-vue only parses the first modifier in a sequence. The original line 126 in `walk.ts` slices the string right after the first modifier is set and thus the while loop never continues. 