### PR TITLE
Bind methods to scope

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
 import { reactive } from '@vue/reactivity'
 import { Block } from './block'
 import { Directive } from './directives'
-import { createContext } from './context'
+import { bindContextMethods, createContext } from './context'
 import { toDisplayString } from './directives/text'
 import { nextTick } from './scheduler'
 
@@ -10,6 +10,7 @@ export const createApp = (initialData?: any) => {
   const ctx = createContext()
   if (initialData) {
     ctx.scope = reactive(initialData)
+    bindContextMethods(ctx.scope)
   }
 
   // global internal helpers

--- a/src/context.ts
+++ b/src/context.ts
@@ -54,8 +54,18 @@ export const createScopedContext = (ctx: Context, data = {}): Context => {
       }
     })
   )
+
+  bindContextMethods(reactiveProxy)
   return {
     ...ctx,
     scope: reactiveProxy
+  }
+}
+
+export const bindContextMethods = (scope: Record<string, any>) => {
+  for (const key of Object.keys(scope)) {
+    if (typeof scope[key] === 'function') {
+      scope[key] = scope[key].bind(scope)
+    }
   }
 }


### PR DESCRIPTION
Methods inside a scope aren't bound to it which causes issues when they're used as a callback (e.g. for `setInterval`, window events, etc.).

Example: https://codesandbox.io/embed/nice-sun-71j3r
(`this.count` should get incremented on `keydown` but it doesn't because `this` inside the `inc()` methods points to `Window` instead of the scope)