### PR TITLE
fix: broken custom delimiters in v-if/v-for

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -27,8 +27,8 @@ export const createContext = (parent?: Context): Context => {
     effects: [],
     blocks: [],
     cleanups: [],
-    delimiters: ['{{', '}}'],
-    delimitersRE: /\{\{([^]+?)\}\}/g,
+    delimiters: parent?.delimiters ?? ['{{', '}}'],
+    delimitersRE: parent?.delimitersRE ?? /\{\{([^]+?)\}\}/g,
     effect: (fn) => {
       if (inOnce) {
         queueJob(fn)

--- a/tests/custom-delimiters.html
+++ b/tests/custom-delimiters.html
@@ -8,4 +8,5 @@
 <div v-scope="{ count: 1 }">
   <p>count is ${ count }!</p>
   <button @click="count++">increase</button>
+  <p v-if="count % 2 == 0">${ count } is even!</p>
 </div>


### PR DESCRIPTION
Fixes a bug where text bindings in `v-if` / `v-for` would fail to be extrapolated while using custom delimiters (but working fine otherwise). The issue is due to the customized delimiters not being properly propagated into `createContext` when these directives are creating `new Block()`-s.

I have also adjusted the `custom-delimiters` test to demonstrate the issue (when unfixed).