### PR TITLE
Minify ESM bundle

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vite'
 import { resolve } from 'path'
 
 export default defineConfig({
+  esbuild: {
+    minify: true
+  },
   build: {
     target: 'esnext',
     minify: 'terser',


### PR DESCRIPTION
Since `vite` in library mode doesn't minify outputs in the ESM format anymore (ref [vuejs/vue-next#2860](https://github.com/vitejs/vite/commit/06d86e4a2e90ca916a43d450bca1e6c28bc4bfe2)), `petite-vue`'s latest ESM bundle is now unminified on all CDNs ([example](https://unpkg.com/petite-vue@0.4.0/dist/petite-vue.es.js?module)). As far as I can tell, there shouldn't be any problems with tree-shaking in our particular case so I updated the config to minify all build outputs once again.