### PR TITLE
README: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ createApp({
 
 ### Lifecycle Events
 
-You can listen to the special `vue:mounted` and `vue:unmounted` lifecycle events for each element (the `vue:` prefixed is required in 0.4.0+):
+You can listen to the special `vue:mounted` and `vue:unmounted` lifecycle events for each element (the `vue:` prefix is required since v0.4.0):
 
 ```html
 <div


### PR DESCRIPTION
What the title says. Also, reword "in 0.4.0+" to "since v0.4.0".