### PR TITLE
feat: add version display

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { createApp } from './app'
 export { nextTick } from './scheduler'
 export { reactive } from '@vue/reactivity'
+export { version } from '../package.json'
 
 import { createApp } from './app'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "rootDir": ".",
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    "resolveJsonModule": true
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
Regarding Petite-vue, when I downloaded it locally, renamed it and used it, I may not have paid attention to what version of the code is. There are versions for common tools to view, so I want to export a version variable to Petite-vue based on this.