### PR TITLE
Update to README: Updated version number to latest version in CDN examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Or, use the ES module build:
 
 The short CDN URL is meant for prototyping. For production usage, use a fully resolved CDN URL to avoid resolving and redirect cost:
 
-- Global build: `https://unpkg.com/petite-vue@0.2.2/dist/petite-vue.iife.js`
+- Global build: `https://unpkg.com/petite-vue@0.4.1/dist/petite-vue.iife.js`
   - exposes `PetiteVue` global, supports auto init
-- ESM build: `https://unpkg.com/petite-vue@0.2.2/dist/petite-vue.es.js`
+- ESM build: `https://unpkg.com/petite-vue@0.4.1/dist/petite-vue.es.js`
   - Must be used with `<script type="module">`
 
 ### Root Scope


### PR DESCRIPTION
Updated the Petite Vue version number inside the Production CDN examples to 0.4.1  from 0.2.2 since there are some significant fixes and changes between the two. 