### PR TITLE
Expose `$el` to `v-scope`

### DIFF
--- a/src/walk.ts
+++ b/src/walk.ts
@@ -39,7 +39,7 @@ export const walk = (node: Node, ctx: Context): ChildNode | null | void => {
 
     // v-scope
     if ((exp = checkAttr(el, 'v-scope')) || exp === '') {
-      const scope = exp ? evaluate(ctx.scope, exp) : {}
+      const scope = exp ? evaluate(ctx.scope, exp, el) : {}
       ctx = createScopedContext(ctx, scope)
       if (scope.$template) {
         resolveTemplate(el, scope.$template)


### PR DESCRIPTION
This small change allows one to use element properties as values for props defined in `v-scope`. For a toy example:
```
<textarea
  v-scope="{width: $el.offsetWidth, height: $el.offsetHeight}"
  @click="width = $el.offsetWidth; height = $el.offsetHeight;"
>{{ width }} &times; {{ height }}</textarea>
```