### PR TITLE
Build script simplification: get rid of `mv dist/src dist/types`; flag moved into tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "types": "./dist/types/index.d.ts",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && tsc --emitDeclarationOnly && mv dist/src dist/types",
+    "build": "vite build && tsc --emitDeclarationOnly",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "release": "node scripts/release.js"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "types": "./dist/types/index.d.ts",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && tsc --emitDeclarationOnly",
+    "build": "vite build && tsc",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "release": "node scripts/release.js"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "rootDir": "src",
+    "emitDeclarationOnly": true,
     "types": ["vite/client"]
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist",
+    "outDir": "dist/types",
     "declaration": true,
     "sourceMap": false,
     "target": "esnext",
@@ -10,7 +10,7 @@
     "allowJs": false,
     "strict": true,
     "noUnusedLocals": true,
-    "rootDir": ".",
+    "rootDir": "src",
     "types": ["vite/client"]
   },
   "include": [


### PR DESCRIPTION
A slight simplification of the build script. 