### PR TITLE
fix: broken examples due to vue:*mounted change

### DIFF
--- a/examples/todomvc.html
+++ b/examples/todomvc.html
@@ -132,7 +132,7 @@
   }).mount('#app')
 </script>
 
-<div id="app" @mounted="setupRouting" v-effect="save()" v-cloak>
+<div id="app" @vue:mounted="setupRouting" v-effect="save()" v-cloak>
   <section class="todoapp">
     <header class="header">
       <h1>todos</h1>


### PR DESCRIPTION
The TodoMVC example is using lifecycle events to set up routing which was not updated to the post-0.4 syntax