### PR TITLE
Add support for input type range

### DIFF
--- a/src/directives/model.ts
+++ b/src/directives/model.ts
@@ -7,7 +7,7 @@ export const model: Directive<
 > = ({ el, exp, get, effect, modifiers }) => {
   const type = el.type
   const assign = get(`(val) => { ${exp} = val }`)
-  const { trim, number = type === 'number' } = modifiers || {}
+  const { trim, number = type === 'number' || type === 'range' } = modifiers || {}
 
   if (el.tagName === 'SELECT') {
     const sel = el as HTMLSelectElement


### PR DESCRIPTION
For now `<input type="range">` is not treated as number type with `v-model` directive. This PR attempts to fix this issue.