### PR TITLE
export the `effect` function as well from entrypoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { createApp } from './app'
 export { nextTick } from './scheduler'
-export { reactive } from '@vue/reactivity'
+export { effect, reactive } from '@vue/reactivity'
 
 import { createApp } from './app'
 


### PR DESCRIPTION
As the petite-vue distribution can't be used alongside a separate installation of @vue/reactivity, it would be helpful to gain access to the `effect` function via an export. Since `effect` is already being used internally, it doesn't increase bundle output, and `effect` can come in handy when using global reactive state outside of a scope.