### PR TITLE
fix: v-if nested in a v-for template tag

### DIFF
--- a/src/directives/if.ts
+++ b/src/directives/if.ts
@@ -13,7 +13,7 @@ export const _if = (el: Element, exp: string, ctx: Context) => {
     console.warn(`v-if expression cannot be empty.`)
   }
 
-  const parent = el.parentElement!
+  const parent = el.parentElement ? el.parentElement : el.parentNode
   const anchor = new Comment('v-if')
   parent.insertBefore(anchor, el)
 


### PR DESCRIPTION
the fix permits nesting an element with a v-if attribute inside a template tag with a v-for attribute like so:
```
<template v-for="item in ['foo', 'bar', 'buzz']">
    <p v-if="item.startsWith('b')">{{ item }} </p>
</template>
```

