### PR TITLE
Fix todomvc example: prefix todomvc mounted hook with "vue:"

### DIFF
--- a/examples/todomvc.html
+++ b/examples/todomvc.html
@@ -132,7 +132,7 @@
   }).mount('#app')
 </script>
 
-<div id="app" @mounted="setupRouting" v-effect="save()" v-cloak>
+<div id="app" @vue:mounted="setupRouting" v-effect="save()" v-cloak>
   <section class="todoapp">
     <header class="header">
       <h1>todos</h1>


### PR DESCRIPTION
The todomvc example has a use of the `@mounted` hook, triggering an error:

> `mounted and unmounted hooks now need to be prefixed with vue: - use @vue:mounted="handler" instead.`

I checked for any other stray uses of `@mounted` or `@unmounted` in the repo to clean up; there were no other instances.